### PR TITLE
Added the option to use a transport configured in another way

### DIFF
--- a/src/GoalioMailService/Mail/Transport/Service/TransportFactory.php
+++ b/src/GoalioMailService/Mail/Transport/Service/TransportFactory.php
@@ -13,17 +13,19 @@ class TransportFactory implements FactoryInterface {
 
         $transportOptions = (isset($config['goaliomailservice']) ? $config['goaliomailservice'] : array());
 
-        if(!isset($transportOptions['transport_class'])) {
-            throw new Exception('Transport class has to be configured');
-        }
+        if(isset($transportOptions['transport_object'])) {
+            $transport = $serviceLocator->get($transportOptions['transport_object']);
+        } elseif (isset($transportOptions['transport_class'])) {
+            $transportClass = $transportOptions['transport_class'];
+            $transport = new $transportClass();
 
-        $transportClass = $transportOptions['transport_class'];
-        $transport = new $transportClass();
-
-        if(isset($transportOptions['options_class'])) {
-            $optionsClass = $transportOptions['options_class'];
-            $options = new $optionsClass($transportOptions['options']);
-            $transport->setOptions($options);
+            if(isset($transportOptions['options_class'])) {
+                $optionsClass = $transportOptions['options_class'];
+                $options = new $optionsClass($transportOptions['options']);
+                $transport->setOptions($options);
+            }
+        } else {
+            throw new Exception('Either transport class or transport object have to be configured');
         }
 
         return $transport;


### PR DESCRIPTION
Currently, the configuration only allows to give the name of a transport class, which will be instantiated.
However, https://github.com/juriansluiman/SlmMail for example, has a factory that returns a transport. That factory uses configuration of its own to create the transport.
So the name of the SlmMail factory is not a class name to instantiate, but rather (returns) an already existing transport.

This PR allows passing an instantiated transport object in the config.
