### PR TITLE
Update composer.json version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.3.*"
+        "zendframework/zendframework": ">=2.3.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
README says this module requires zf2 `>2.3.3`.  The current requirement in composer is `2.3.*` (which could cause invalid versions like 2.3.0 to be loaded).  The module also works fine in `2.4.0`.  I don't know whether `>=` is discouraged, but I'm submitting `>=2.3.3` and am open to anything that gets 2.4 into the scope.
